### PR TITLE
Fix support symbols < > = (with space) and guillemets marks << >> with synced highlight

### DIFF
--- a/.changeset/shaggy-streets-cover.md
+++ b/.changeset/shaggy-streets-cover.md
@@ -1,0 +1,5 @@
+---
+"@chialab/speaker": patch
+---
+
+Fix support symbols > < = and guillemets marks << >>

--- a/src/Speaker.ts
+++ b/src/Speaker.ts
@@ -8,18 +8,55 @@ import {
     type SentenceToken,
     TokenType,
     TokenWalker,
+    substituteSymbolsToSegments,
 } from './Tokenizer';
 import { Utterance } from './Utterance';
 
 /** Default map: symbol -> spoken word per language. */
 const DEFAULT_SYMBOLS_TO_WORDS: Record<string, Record<string, string>> = {
-    en: { '<': 'less than', '>': 'greater than' },
-    it: { '<': 'minore', '>': 'maggiore' },
-    es: { '<': 'menor que', '>': 'mayor que' },
-    fr: { '<': 'inférieur à', '>': 'supérieur à' },
-    de: { '<': 'kleiner als', '>': 'größer als' },
-    pt: { '<': 'menor que', '>': 'maior que' },
+    en: { '<<': '', '>>': '', '<': 'less than', '>': 'greater than' },
+    it: { '<<': '', '>>': '', '<': 'minore', '>': 'maggiore' },
+    es: { '<<': '', '>>': '', '<': 'menor que', '>': 'mayor que' },
+    fr: { '<<': '', '>>': '', '<': 'inférieur à', '>': 'supérieur à' },
+    de: { '<<': '', '>>': '', '<': 'kleiner als', '>': 'größer als' },
+    pt: { '<<': '', '>>': '', '<': 'menor que', '>': 'maior que' },
 };
+
+/** Returns tokens to speak (expanded segments or single token), only non-empty text. */
+function getTokensToSpeak(
+    childToken: BoundaryToken,
+    symbolsToWords: Record<string, Record<string, string>>,
+    defaultLang: string
+): BoundaryToken[] {
+    if (
+        !childToken.rawText ||
+        childToken.rawText === childToken.text ||
+        childToken.startNode !== childToken.endNode ||
+        !Object.keys(symbolsToWords).length
+    ) {
+        return childToken.text.trim() ? [childToken] : [];
+    }
+    const segments = substituteSymbolsToSegments(
+        childToken.rawText,
+        childToken.lang || defaultLang,
+        symbolsToWords
+    ).segments.filter((seg) => seg.text.length > 0);
+    if (segments.length === 0) {
+        return [];
+    }
+
+    return segments.map((seg) => ({
+        type: TokenType.BOUNDARY,
+        text: seg.text,
+        startNode: childToken.startNode,
+        startOffset: childToken.startOffset + seg.startOffset,
+        endNode: childToken.endNode,
+        endOffset: childToken.startOffset + seg.endOffset,
+        lang: childToken.lang,
+        voiceType: childToken.voiceType,
+        voice: childToken.voice,
+    }));
+}
 
 /**
  * Speaker options.
@@ -300,6 +337,7 @@ export class Speaker extends Emitter<{
                     break;
                 case TokenType.BLOCK: {
                     const queue: Utterance[] = [];
+                    const symbolsToWords = this.#options.symbolsToWords ?? DEFAULT_SYMBOLS_TO_WORDS;
 
                     for (let index = 0, len = token.tokens.length; index < len; index++) {
                         const childToken = token.tokens[index];
@@ -327,15 +365,21 @@ export class Speaker extends Emitter<{
                                     block: token as BlockToken,
                                     sentence:
                                         sentences.find((sentenceToken) =>
-                                            sentenceToken.tokens.includes(currentToken)
+                                            sentenceToken.tokens.some(
+                                                (t) =>
+                                                    t.startNode === currentToken.startNode &&
+                                                    t.startOffset <= currentToken.startOffset &&
+                                                    t.endOffset >= currentToken.endOffset
+                                            )
                                         ) ?? null,
                                 });
                             });
                             queue.push(currentUtterance);
                         }
 
-                        if (currentUtterance.length || childToken.text.trim()) {
-                            currentUtterance.addToken(childToken);
+                        // Expand to segments when needed (highlight sync); skip empty (e.g. << >>)
+                        for (const t of getTokensToSpeak(childToken, symbolsToWords, this.#lang)) {
+                            currentUtterance.addToken(t);
                         }
                     }
 

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -30,6 +30,8 @@ export interface TextToken extends Token {
     lang: string | null;
     voice: string | null;
     voiceType: string | null;
+    /** Original text before symbol substitution (used by Speaker for segment highlight sync). */
+    rawText?: string;
 }
 
 /**
@@ -93,19 +95,86 @@ function createCheckFunction(rules?: CheckRule, deep = false): CheckFunction {
     return () => false;
 }
 
+export interface SymbolSegment {
+    text: string;
+    startOffset: number;
+    endOffset: number;
+}
+
+export interface SubstituteSymbolsResult {
+    segments: SymbolSegment[];
+    text: string;
+}
+
 /**
- * Substitute symbols with spoken words using the given map.
- * @param text The text to substitute.
- * @param lang The language of the text.
- * @param map The map of symbols to spoken words.
- * @returns The substituted text.
+ * Split text into segments (each substituted symbol gets its own segment for highlight sync)
+ * and return also the joined non-empty text. Offsets relative to chunk (0..rawText.length).
  */
-function substituteSymbols(text: string, lang: string, map?: Record<string, Record<string, string>>): string {
-    if (!map) {
-        return text;
+export function substituteSymbolsToSegments(
+    rawText: string,
+    lang: string,
+    map?: Record<string, Record<string, string>>
+): SubstituteSymbolsResult {
+    let segments: SymbolSegment[];
+    if (!map || !rawText) {
+        segments = [{ text: rawText, startOffset: 0, endOffset: rawText.length }];
+    } else {
+        const normalizedLang = lang.split(/[-_]/)[0].toLowerCase();
+        const langMap = map[normalizedLang];
+        if (!langMap) {
+            segments = [{ text: rawText, startOffset: 0, endOffset: rawText.length }];
+        } else {
+            const entries = Object.entries(langMap).sort(([a], [b]) => b.length - a.length);
+            segments = [];
+            let i = 0;
+            while (i < rawText.length) {
+                let found: { symbol: string; word: string } | null = null;
+                for (const [symbol, word] of entries) {
+                    if (rawText.substring(i, i + symbol.length) === symbol) {
+                        found = { symbol, word };
+                        break;
+                    }
+                }
+                if (found) {
+                    let j = i + found.symbol.length;
+                    while (j < rawText.length && /[,\s]/.test(rawText[j])) {
+                        j++;
+                    }
+                    segments.push({
+                        text: found.word + rawText.substring(i + found.symbol.length, j),
+                        startOffset: i,
+                        endOffset: i + found.symbol.length,
+                    });
+                    i = j;
+                } else {
+                    let runEnd = i + 1;
+                    while (runEnd < rawText.length) {
+                        let matchHere = false;
+                        for (const [symbol] of entries) {
+                            if (rawText.substring(runEnd, runEnd + symbol.length) === symbol) {
+                                matchHere = true;
+                                break;
+                            }
+                        }
+                        if (matchHere) break;
+                        runEnd++;
+                    }
+                    segments.push({
+                        text: rawText.substring(i, runEnd),
+                        startOffset: i,
+                        endOffset: runEnd,
+                    });
+                    i = runEnd;
+                }
+            }
+            if (segments.length === 0) {
+                segments = [{ text: rawText, startOffset: 0, endOffset: rawText.length }];
+            }
+        }
     }
-    const normalizedLang = lang.split(/[-_]/)[0].toLowerCase();
-    return map[normalizedLang]?.[text] ?? text;
+    const text = segments.filter((s) => s.text.length > 0).map((s) => s.text).join('');
+
+    return { segments, text };
 }
 
 /**
@@ -510,7 +579,8 @@ export function* tokenize(
                     const lang = getNodeLang(startNode, root);
                     const token: BoundaryToken = {
                         type: TokenType.BOUNDARY,
-                        text: substituteSymbols(rawText, lang || defaultLang, symbolsToWords),
+                        text: substituteSymbolsToSegments(rawText, lang || defaultLang, symbolsToWords).text,
+                        rawText,
                         startNode,
                         startOffset,
                         endNode,
@@ -569,7 +639,8 @@ export function* tokenize(
                     const lang = getNodeLang(currentNode, root);
                     const token: BoundaryToken = {
                         type: TokenType.BOUNDARY,
-                        text: substituteSymbols(rawText, lang || defaultLang, symbolsToWords),
+                        text: substituteSymbolsToSegments(rawText, lang || defaultLang, symbolsToWords).text,
+                        rawText,
                         startNode: range.startContainer,
                         startOffset: range.startOffset,
                         endNode: range.endContainer,
@@ -629,7 +700,8 @@ export function* tokenize(
                 const lang = getNodeLang(startNode, root);
                 const token: BoundaryToken = {
                     type: TokenType.BOUNDARY,
-                    text: substituteSymbols(rawText, lang || defaultLang, symbolsToWords),
+                    text: substituteSymbolsToSegments(rawText, lang || defaultLang, symbolsToWords).text,
+                    rawText,
                     startNode,
                     startOffset,
                     endNode,
@@ -713,7 +785,8 @@ export function* tokenize(
             const rawText = chunk.replace(textFilterRegexp, textFilterReplacement);
             const token: BoundaryToken = {
                 type: TokenType.BOUNDARY,
-                text: substituteSymbols(rawText, lang || defaultLang, symbolsToWords),
+                text: substituteSymbolsToSegments(rawText, lang || defaultLang, symbolsToWords).text,
+                rawText,
                 startNode,
                 startOffset,
                 endNode,
@@ -782,7 +855,8 @@ export function* tokenize(
         const lang = getNodeLang(startNode, root);
         const token: BoundaryToken = {
             type: TokenType.BOUNDARY,
-            text: substituteSymbols(rawText, lang || defaultLang, symbolsToWords),
+            text: substituteSymbolsToSegments(rawText, lang || defaultLang, symbolsToWords).text,
+            rawText,
             startNode,
             startOffset,
             endNode,


### PR DESCRIPTION
- **Comparison symbols and guillemets**: `symbolsToWords` map with `<<`/`>>` (empty string, not spoken), `<`/`>` (e.g. "less than"/"greater than"). Substitution is per-symbol, longer sequences first so `<<`/`>>` are applied before `<`/`>`.
- **Single helper**: `substituteSymbolsToSegments(rawText, lang, map)` returns `{ segments, text }`: segments for highlight sync, `text` for the token. Used in Tokenizer for `token.text` and in Speaker for segment expansion.
- **Tokens carry `rawText`**: Tokenizer adds `rawText` to each boundary; Speaker expands into multiple tokens when `rawText !== text` and a single node, so highlight follows each spoken word (e.g. only `>` when saying "greater than"). Tokens with empty text (`<<`/`>>`) are not added to the utterance.
- **Speaker helper**: `getTokensToSpeak(childToken, symbolsToWords, defaultLang)` returns the tokens to speak (segments or single token), non-empty only. Boundary callback finds the sentence by overlapping range for segment tokens.