### PR TITLE
Substitute comparison symbols fix

### DIFF
--- a/.changeset/eight-apes-own.md
+++ b/.changeset/eight-apes-own.md
@@ -1,0 +1,5 @@
+---
+"@chialab/speaker": patch
+---
+
+fix: substitute comparison symbols

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -95,12 +95,6 @@ function createCheckFunction(rules?: CheckRule, deep = false): CheckFunction {
 
 /**
  * Substitute comparison symbols with spoken words using the given map.
- * A symbol is substituted only when neither the character immediately before
- * nor the one immediately after it is itself a symbol character (i.e. a character
- * that appears in any key of the map for the given language).
- * This prevents substituting symbols that are part of a multi-symbol sequence
- * (e.g. `>>` or `<>`) while still substituting symbols adjacent to other
- * characters such as punctuation (e.g. `>,`).
  *
  * @param text The text to substitute.
  * @param lang The language of the text.
@@ -118,35 +112,12 @@ function substituteSymbols(text: string, lang: string, map?: Record<string, Reco
         return text;
     }
 
-    const symbols = Object.keys(langMap).sort((a, b) => b.length - a.length);
-    const symbolChars = new Set(symbols.flatMap((s) => [...s]));
+    const symbols = Object.keys(langMap)
+        .filter((s) => s && langMap[s] != null)
+        .sort((a, b) => b.length - a.length);
 
-    let result = text;
-    for (const symbol of symbols) {
-        if (!symbol) continue;
-        const replacement = langMap[symbol];
-        if (replacement == null) continue;
-
-        let i = 0;
-        let output = '';
-        while (i < result.length) {
-            if (result.startsWith(symbol, i)) {
-                const prev = i > 0 ? result[i - 1] : '';
-                const next = result[i + symbol.length] ?? '';
-                if ((!prev || !symbolChars.has(prev)) && (!next || !symbolChars.has(next))) {
-                    output += replacement;
-                } else {
-                    output += symbol;
-                }
-                i += symbol.length;
-            } else {
-                output += result[i++];
-            }
-        }
-        result = output;
-    }
-
-    return result;
+    const pattern = new RegExp(symbols.map((s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')).join('|'), 'g');
+    return text.replace(pattern, (match) => langMap[match]);
 }
 
 /**

--- a/src/Tokenizer.ts
+++ b/src/Tokenizer.ts
@@ -94,18 +94,59 @@ function createCheckFunction(rules?: CheckRule, deep = false): CheckFunction {
 }
 
 /**
- * Substitute symbols with spoken words using the given map.
+ * Substitute comparison symbols with spoken words using the given map.
+ * A symbol is substituted only when neither the character immediately before
+ * nor the one immediately after it is itself a symbol character (i.e. a character
+ * that appears in any key of the map for the given language).
+ * This prevents substituting symbols that are part of a multi-symbol sequence
+ * (e.g. `>>` or `<>`) while still substituting symbols adjacent to other
+ * characters such as punctuation (e.g. `>,`).
+ *
  * @param text The text to substitute.
  * @param lang The language of the text.
- * @param map The map of symbols to spoken words.
+ * @param map The map of comparison symbols to spoken words, keyed by short lang code.
  * @returns The substituted text.
  */
 function substituteSymbols(text: string, lang: string, map?: Record<string, Record<string, string>>): string {
     if (!map) {
         return text;
     }
+
     const normalizedLang = lang.split(/[-_]/)[0].toLowerCase();
-    return map[normalizedLang]?.[text] ?? text;
+    const langMap = map[normalizedLang] ?? map[lang.toLowerCase()];
+    if (!langMap) {
+        return text;
+    }
+
+    const symbols = Object.keys(langMap).sort((a, b) => b.length - a.length);
+    const symbolChars = new Set(symbols.flatMap((s) => [...s]));
+
+    let result = text;
+    for (const symbol of symbols) {
+        if (!symbol) continue;
+        const replacement = langMap[symbol];
+        if (replacement == null) continue;
+
+        let i = 0;
+        let output = '';
+        while (i < result.length) {
+            if (result.startsWith(symbol, i)) {
+                const prev = i > 0 ? result[i - 1] : '';
+                const next = result[i + symbol.length] ?? '';
+                if ((!prev || !symbolChars.has(prev)) && (!next || !symbolChars.has(next))) {
+                    output += replacement;
+                } else {
+                    output += symbol;
+                }
+                i += symbol.length;
+            } else {
+                output += result[i++];
+            }
+        }
+        result = output;
+    }
+
+    return result;
 }
 
 /**


### PR DESCRIPTION
Substitute each symbol found in the raw text. This handles also cases like ">," or similar ones.
The regex is built dinamycally. It first escapes special characters then handles the substitution