### PR TITLE
Local service filtering 

### DIFF
--- a/.changeset/moody-carpets-fetch.md
+++ b/.changeset/moody-carpets-fetch.md
@@ -1,0 +1,5 @@
+---
+"@chialab/speaker": patch
+---
+
+Local service filtering 

--- a/src/Adapter.ts
+++ b/src/Adapter.ts
@@ -42,9 +42,11 @@ let VOICES_PROMISE: Promise<SpeechSynthesisVoice[]>;
 /**
  * Get speech synthesis voices.
  * @param timeoutTime Timeout time in milliseconds.
+ * @param filterLocals Filter out non local voices.
+ *
  * @returns A promise that resolves voices.
  */
-export function getVoices(timeoutTime = 2000): Promise<SpeechSynthesisVoice[]> {
+export function getVoices(timeoutTime = 2000, filterLocals = true): Promise<SpeechSynthesisVoice[]> {
     if (!VOICES_PROMISE) {
         VOICES_PROMISE = new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
@@ -55,7 +57,10 @@ export function getVoices(timeoutTime = 2000): Promise<SpeechSynthesisVoice[]> {
                 let voices = getSpeechSynthesis().getVoices();
                 if (voices.length) {
                     clearTimeout(timeout);
-                    voices = [...voices].filter((voice) => voice.localService);
+                    voices = [...voices];
+                    if (filterLocals) {
+                        voices = voices.filter((voice) => voice.localService);
+                    }
                     if (!voices.length) {
                         reject(new Error('Cannot retrieve offline voices'));
                         return false;


### PR DESCRIPTION
In some cases (e.g. on Chrome Windows) always filtering by "local service" is too strict, resulting in very few voices available for the user (e.g. on Windows 11, latest chrome, we now filter 19/21 voices)
We may set the filter using an optional parameter.